### PR TITLE
Revert and freeze gradle version to avoid 4.0.0 bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.google.gms:google-services:4.2.0'
     }
 }


### PR DESCRIPTION
Released yesterday, the gradle 4.0.0 version causes this compilation error:
```Application build has failed with an error (Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.60-eap-25)````

Source: https://androidstudio.googleblog.com/2019/10/android-studio-40-canary-1-available.html

This pull request reverts the dependency to the last working version.